### PR TITLE
Add mountPath option for router prefix

### DIFF
--- a/lib/botmaster.js
+++ b/lib/botmaster.js
@@ -129,7 +129,7 @@ class Botmaster extends EventEmitter {
     if (bot.requiresWebhook) {
       const path = `/${bot.type}/${bot.webhookEndpoint}`;
       if(bot.mountPath){
-        path = ${bot.mountPath} + path
+        path = `/${bot.mountPath}` + path
       }
       this.__serverRequestListeners[path] = bot.requestListener;
     }

--- a/lib/botmaster.js
+++ b/lib/botmaster.js
@@ -128,6 +128,9 @@ class Botmaster extends EventEmitter {
   addBot(bot) {
     if (bot.requiresWebhook) {
       const path = `/${bot.type}/${bot.webhookEndpoint}`;
+      if(bot.mountPath){
+        path = ${bot.mountPath} + path
+      }
       this.__serverRequestListeners[path] = bot.requestListener;
     }
     bot.master = this;


### PR DESCRIPTION
Hi,
A small change to change the mounting path, when the backend running under /api path for example : /api/messenger/webhook.
Feel free to change the option name if `mountPath` is not self explanatory.