### PR TITLE
Trim slashes from webhook endpoint string

### DIFF
--- a/lib/botmaster.js
+++ b/lib/botmaster.js
@@ -127,6 +127,7 @@ class Botmaster extends EventEmitter {
    */
   addBot(bot) {
     if (bot.requiresWebhook) {
+      const webhookEndpoint = bot.webhookEndpoint.replace(/^\/|\/$/g, '');
       const path = `/${bot.type}/${bot.webhookEndpoint}`;
       this.__serverRequestListeners[path] = bot.requestListener;
     }


### PR DESCRIPTION
Documentation for individual bots contains examples with webhooks
containing slashes (e.g. '/webhook1234/'). This results in a path
containing two slashes. This fix makes sure that the user can use
endpoint string with or without slashes.