### PR TITLE
Adds settings.pages to enable one bot instance to listen to more than

### DIFF
--- a/lib/base_bot.js
+++ b/lib/base_bot.js
@@ -118,6 +118,14 @@ class BaseBot extends EventEmitter {
     } else if (settings.webhookEndpoint) {
       throw new Error(`bots of type '${this.type}' do not require webhookEndpoint in their settings`);
     }
+
+    if (settings.pages) {
+      for (const pageId in settings.pages) {
+        if (!settings.pages[pageId].pageToken) {
+          throw new Error(`All pages are expected to have a pageToken. Page "${pageId}" is missing it.`);
+        }
+      }
+    }
   }
 
   /**

--- a/tests/base_bot/applySettings.js
+++ b/tests/base_bot/applySettings.js
@@ -103,3 +103,37 @@ test(`${errorTestTitleBase} with a webhookEndpoint although it does not requires
     t.is(err.message.indexOf('do not require webhookEndpoint in') > -1, true);
   }
 });
+
+test(`${errorTestTitleBase} with 'pages' being passed and one of the pages' token is not defined`, (t) => {
+  t.plan(1);
+  const botSettings = {
+    pages: {
+      '123x': {
+        pageToken: '',
+      },
+    },
+  };
+
+  try {
+    const bot = new MockBot(botSettings);
+  } catch (err) {
+    t.is(err.message, 'All pages are expected to have a pageToken. Page "123x" is missing it.');
+  }
+});
+
+test(`${successTestTitleBase} with 'pages' being passed and pages' tokens all defined`, (t) => {
+  t.plan(1);
+  const botSettings = {
+    pages: {
+      '123x': {
+        pageToken: '123xtoken',
+      },
+      '432y': {
+        pageToken: '432ytoken',
+      },
+    },
+  };
+
+  const bot = new MockBot(botSettings);
+  t.pass();
+});


### PR DESCRIPTION
(Related to https://github.com/botmasterai/botmaster-messenger/issues/5)

This is needed because eg. in FB, one app can subscribe to changes in
more than one page, so we need to enable one bot to listen to more than
one pages.