### PR TITLE
Changes the way botmaster patches the bot for the middlewares

### DIFF
--- a/lib/base_bot.js
+++ b/lib/base_bot.js
@@ -250,7 +250,7 @@ class BaseBot extends EventEmitter {
       let outgoingMiddlewarePromise;
       if (this.master && !sendOptions.ignoreMiddleware) {
         outgoingMiddlewarePromise = this.master.middleware.__runOutgoingMiddleware(
-          this, sendOptions.__update, outgoingMessage);
+          this, this.__associatedUpdate, outgoingMessage);
       } else {
         // don't actually go through middleware
         outgoingMiddlewarePromise = Promise.resolve(outgoingMessage);
@@ -751,12 +751,12 @@ class BaseBot extends EventEmitter {
    * @return {Promise} promise that resolves into the user info or an empty
    * object by default
    */
-  getUserInfo(userId) {
+  getUserInfo(userId, options) {
     if (!this.retrievesUserInfo) {
       return Promise.reject(TypeError(
         `Bots of type ${this.type} don't provide access to user info.`));
     }
-    return this.__getUserInfo(userId);
+    return this.__getUserInfo(userId, options);
   }
 
   /**
@@ -771,18 +771,7 @@ class BaseBot extends EventEmitter {
    */
   __createBotPatchedWithUpdate(update) {
     const newBot = Object.create(this);
-    newBot.sendMessage = (message, sendOptions) => {
-      sendOptions = sendOptions || {};
-
-      // validating here too, as __update has to be added to a valid
-      // sendOptions object
-      return this.__validateSendOptions(sendOptions)
-
-      .then(() => {
-        sendOptions.__update = update;
-        return this.sendMessage(message, sendOptions);
-      });
-    };
+    newBot.__associatedUpdate = update;
     return newBot;
   }
 }

--- a/tests/middleware/use.js
+++ b/tests/middleware/use.js
@@ -700,8 +700,8 @@ test('sets up the outgoing middleware which is ignored if specified so in sendOp
   });
 });
 
-test('sets up the outgoing middleware which is aware of update when manually set using sendOptions. or __createBotPatchedWithUpdate', (t) => {
-  t.plan(4);
+test('sets up the outgoing middleware which is aware of update when manually set using __createBotPatchedWithUpdate', (t) => {
+  t.plan(2);
 
   return new Promise(async (resolve) => {
     const botmaster = t.context.botmaster;
@@ -719,9 +719,6 @@ test('sets up the outgoing middleware which is aware of update when manually set
 
     const bot = botmaster.bots[0];
     try {
-      await bot.sendMessage(
-        outgoingMessageFixtures.textMessage(), { __update: mockUpdate });
-
       // with a patchedBot
       const patchedBot = bot.__createBotPatchedWithUpdate(mockUpdate);
       await patchedBot.sendMessage(outgoingMessageFixtures.textMessage());
@@ -805,4 +802,3 @@ test('sets up the outgoing middleware which is aware of update on the second pas
     t.context.bot.__emitUpdate(receivedUpdate);
   });
 });
-


### PR DESCRIPTION
It now just creates a new instance of the bot and sets a variable called
__associatedUpdate that points to the update object.
This is necessary because other methods such as getUserInfo and
_messengerProfileRequest don't receive sendOptions. So we won't use
sendOptions for keeping track of the update's recipient id.

Relates to https://github.com/botmasterai/botmaster-messenger/issues/5