### PR TITLE
Adds update object to generic error event.

### DIFF
--- a/lib/base_bot.js
+++ b/lib/base_bot.js
@@ -740,7 +740,7 @@ class BaseBot extends EventEmitter {
         err.message = `"${err.message}". This is most probably on your end.`;
       }
 
-      this.emit('error', err || 'empty error object');
+      this.emit('error', err || 'empty error object', update);
       return err;
     });
   }

--- a/lib/botmaster.js
+++ b/lib/botmaster.js
@@ -132,9 +132,9 @@ class Botmaster extends EventEmitter {
     }
     bot.master = this;
     this.bots.push(bot);
-    bot.on('error', (err) => {
+    bot.on('error', (err, update) => {
       debug(err.message);
-      this.emit('error', bot, err);
+      this.emit('error', bot, err, update);
     });
 
     debug(`added bot of type: ${bot.type} with id: ${bot.id}`);


### PR DESCRIPTION
This change will allow to pass more context on error event and handle it properly. Bot reference is not enough, because update object can hold lot of context details. 